### PR TITLE
Allows Threeman to open new tab instead of new window

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Threeman
 
-Threeman is an alternative to [Foreman](https://github.com/ddollar/foreman).  Rather than running all the commands together in one terminal, it opens a new terminal window with each command in a tab.  The benefits of this are:
+Threeman is an alternative to [Foreman](https://github.com/ddollar/foreman).  Rather than running all the commands together in one terminal, it opens a tab for each command.  The benefits of this are:
 
 * Your terminal app will notify you using an icon when there's new output from each command
 * Because your command's input and output aren't being intercepted by Foreman, you can use [Pry](http://pryrepl.org)

--- a/lib/threeman/cli.rb
+++ b/lib/threeman/cli.rb
@@ -52,13 +52,13 @@ module Threeman
         exit! 1
       end
 
-      valid_frontend_open_option(frontend_name) if options[:open_in_new_tab]
+      valid_frontend_open_option?(frontend_name) if options[:open_in_new_tab]
 
       frontend(frontend_name, options).run_commands(commands)
     end
 
     private
-    def valid_frontend_open_option(frontend_name)
+    def valid_frontend_open_option?(frontend_name)
       unless frontend_name == :iterm3
         puts "Opening in a new tab is only supported for iterm3"
         exit! 1

--- a/lib/threeman/cli.rb
+++ b/lib/threeman/cli.rb
@@ -23,9 +23,22 @@ module Threeman
 
     desc "start", "Start the application"
     option :frontend, desc: "Which frontend to use.  One of: #{FRONTENDS.keys.sort.join(', ')}"
-    option :panes, desc: "Runs each command in a pane, if supported by the frontend.  (Currently supported in iterm3 and tmux.)", type: :array
-    option :port, desc: "The port to run the application on.  This will set the PORT environment variable.", type: :numeric
     option :layout_name, desc: "If using tmux, the layout name to use for paned commands", type: :string
+    option(
+      :open_in_new_tab,
+      desc: "If using iterm3, configure how threeman opens",
+      type: :boolean
+    )
+    option(
+      :panes,
+      desc: "Runs each command in a pane, if supported by the frontend.  (Currently supported in iterm3 and tmux.)",
+      type: :array
+    )
+    option(
+      :port,
+      desc: "The port to run the application on.  This will set the PORT environment variable.",
+      type: :numeric
+    )
 
     def start
       pwd = Dir.pwd
@@ -39,10 +52,19 @@ module Threeman
         exit! 1
       end
 
+      valid_frontend_open_option(frontend_name) if options[:open_in_new_tab]
+
       frontend(frontend_name, options).run_commands(commands)
     end
 
     private
+    def valid_frontend_open_option(frontend_name)
+      unless frontend_name == :iterm3
+        puts "Opening in a new tab is only supported for iterm3"
+        exit! 1
+      end
+    end
+
     def frontend(name, options = {})
       frontend_lambda = FRONTENDS[name.to_sym]
       unless frontend_lambda

--- a/lib/threeman/frontends/iterm3.rb
+++ b/lib/threeman/frontends/iterm3.rb
@@ -12,7 +12,7 @@ module Threeman
       def run_commands(commands)
         iterm = Appscript.app("iTerm")
         iterm.activate
-        window = iterm.create_window_with_default_profile
+        window = open_option(iterm)
 
         sort_commands(commands).each_with_index do |command, index|
           current_tab = if index == 0
@@ -34,6 +34,21 @@ module Threeman
         cd_cmd = "cd #{Shellwords.escape command.workdir}"
         bash_cmd = "bash -c #{Shellwords.escape bash_script(command)}"
         session.write(text: [cd_cmd, bash_cmd].join("\n"))
+      end
+
+      def open_option(iterm)
+        if options[:open_in_new_tab]
+          begin
+            current_window = iterm.current_window
+          rescue Appscript::CommandError
+            puts "Cannot open in new iterm tab because there is no existing iterm window"
+            exit! 1
+          end
+          current_window.create_tab_with_default_profile
+          current_window
+        else
+          iterm.create_window_with_default_profile
+        end
       end
     end
   end

--- a/lib/threeman/frontends/iterm3.rb
+++ b/lib/threeman/frontends/iterm3.rb
@@ -38,12 +38,7 @@ module Threeman
 
       def open_option(iterm)
         if options[:open_in_new_tab]
-          begin
-            current_window = iterm.current_window
-          rescue Appscript::CommandError
-            puts "Cannot open in new iterm tab because there is no existing iterm window"
-            exit! 1
-          end
+          current_window = iterm.current_window
           current_window.create_tab_with_default_profile
           current_window
         else

--- a/threeman.gemspec
+++ b/threeman.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["nbudin@patientslikeme.com"]
 
   spec.summary       = %q{Runs Procfile commands in tabs}
-  spec.description   = %q{An alternative to Foreman for Mac users, which runs each command in a separate tab}
+  spec.description   = %q{An alternative to Foreman, which runs each command in a separate tab}
   spec.homepage      = "https://github.com/patientslikeme/threeman"
   spec.license       = "MIT"
 

--- a/threeman.gemspec
+++ b/threeman.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Nat Budin"]
   spec.email         = ["nbudin@patientslikeme.com"]
 
-  spec.summary       = %q{Runs Procfile commands in iTerm 2 tabs}
-  spec.description   = %q{An alternative to Foreman for Mac users, which runs each command in a separate iTerm 2 tab}
+  spec.summary       = %q{Runs Procfile commands in tabs}
+  spec.description   = %q{An alternative to Foreman for Mac users, which runs each command in a separate tab}
   spec.homepage      = "https://github.com/patientslikeme/threeman"
   spec.license       = "MIT"
 


### PR DESCRIPTION
When starting Threeman using iTerm, you can now add the flag 'open-in-new-tab' to indicate that you don't want Threeman to open a new window, but rather a new tab.

WIP: Handle the case where someone adds argument to open in new tab when there isn't already an open iTerm window. 
Currently, if this is done, this error message happens:
```astansbury@hq-PLM0445-pro:~/threeman (iterm3_open_option)$ threeman start --open-in-new-tab
/usr/local/var/rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rb-scpt-1.0.2/lib/rb-scpt.rb:542:in `_send_command': CommandError (Appscript::CommandError)
		OSERROR: -1728
		MESSAGE: Can't get reference.
		OFFENDING OBJECT: app("/Applications/iTerm.app").current_window
		COMMAND: app("/Applications/iTerm.app").current_window.current_session.write({:text=>"cd /Users/astansbury/threeman\nbash -c echo\\ -ne\\ \\\"\\\\033\\]0\\;one\\\\007\\\"\\ \\;\\ export\\ PORT\\=5000\\ \\;\\ echo\\ 1\\;\\ sleep\\ 10"})
	from /usr/local/var/rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rb-scpt-1.0.2/lib/rb-scpt.rb:642:in `method_missing'
	from /usr/local/var/rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/threeman-0.5.0/lib/threeman/frontends/iterm3.rb:36:in `run_command'
	from /usr/local/var/rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/threeman-0.5.0/lib/threeman/frontends/iterm3.rb:28:in `block in run_commands'
	from /usr/local/var/rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/threeman-0.5.0/lib/threeman/frontends/iterm3.rb:17:in `each'
	from /usr/local/var/rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/threeman-0.5.0/lib/threeman/frontends/iterm3.rb:17:in `each_with_index'
	from /usr/local/var/rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/threeman-0.5.0/lib/threeman/frontends/iterm3.rb:17:in `run_commands'
	from /usr/local/var/rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/threeman-0.5.0/lib/threeman/cli.rb:57:in `start'
	from /usr/local/var/rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
	from /usr/local/var/rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	from /usr/local/var/rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
	from /usr/local/var/rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
	from /usr/local/var/rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/threeman-0.5.0/exe/threeman:5:in `<top (required)>'
	from /usr/local/var/rbenv/versions/2.3.3/bin/threeman:22:in `load'
	from /usr/local/var/rbenv/versions/2.3.3/bin/threeman:22:in `<main>'
```